### PR TITLE
Add export subtitles capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
                     <div class="menu-options" id="menu-options">
                         <button id="fullscreen-button">Full Screen</button>
                         <button id="toggle-retime-buttons">Show Retiming Buttons</button>
+                        <button id="export-subtitles">Export Subtitles</button>
                         <button id="save-unknown-words">Export Unknown Words</button>
                         <button id="load-unknown-words">Import Unknown Words</button>
                     </div>


### PR DESCRIPTION
## Summary
- add **Export Subtitles** button to the subtitle panel menu
- track subtitle format on load and add helper to export subtitles
- implement function to generate SRT output and download file

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f5d7fec8322a224aec7c08c11e9