### PR TITLE
Fix retime function to keep previous adjustments

### DIFF
--- a/script.js
+++ b/script.js
@@ -506,12 +506,12 @@ function retimeSubtitles(index) {
     const currentTime = video.currentTime;
     const sub = subtitles[index];
     const timeDifference = currentTime - sub.start;
-    
-    subtitles.forEach((subtitle) => {
-        subtitle.start += timeDifference;
-        subtitle.end += timeDifference;
-    });
-    
+
+    for (let i = index; i < subtitles.length; i++) {
+        subtitles[i].start += timeDifference;
+        subtitles[i].end += timeDifference;
+    }
+
     displaySubtitles(subtitles);
 }
 


### PR DESCRIPTION
## Summary
- retimeSubtitles now shifts timestamps from the selected index onward instead of shifting all subtitles

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f84112ce8832296290717c61161f0