### PR TITLE
Implement Condense Audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                         <button id="export-subtitles">Export Subtitles</button>
                         <button id="save-unknown-words">Export Unknown Words</button>
                         <button id="load-unknown-words">Import Unknown Words</button>
+                        <button id="condense-audio">Condense Audio</button>
                     </div>
                 </div>
                 <button id="toggle-subtitle-panel" class="toggle-subtitle-panel-button">
@@ -78,6 +79,7 @@
             <button id="close-modal">Close</button>
         </div>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lamejs/1.2.0/lame.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `lamejs` script to encode audio
- support condensing audio to speech segments based on subtitles
- enable exporting condensed audio as MP3
- fix MP3 encoding by converting Float32 samples to Int16

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68521342b42083228ab0a9bcad07731b